### PR TITLE
fix: replace wrong exception class usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import queue
 import re
 import uuid
 from multiprocessing import get_context, Queue
@@ -16,7 +17,6 @@ import hashlib
 import shutil
 import base64
 import json
-import multiprocessing
 
 # Load environment variables
 load_dotenv()
@@ -211,8 +211,8 @@ async def process_pdf_job(job_id: str, file_path: Path, safe_filename: str, conf
             await asyncio.sleep(0.2)
 
         try:
-            result = result_queue.get(timeout=1)
-        except multiprocessing.queues.Queue:
+            result = result_queue.get(timeout=5)
+        except queue.Empty:
             result = None
 
         if not result:


### PR DESCRIPTION
This pull request makes minor adjustments to how queues are handled in `main.py`, specifically in the context of processing PDF jobs. The main change is the switch from using `multiprocessing.queues.Queue` to the standard `queue` module for exception handling, along with a slight increase in the queue timeout.

Queue handling improvements:

* Imported the `queue` module and removed the unused `multiprocessing` import to streamline exception handling. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R3) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L19)
* Updated the exception handling in `process_pdf_job` to catch `queue.Empty` instead of `multiprocessing.queues.Queue`, and increased the timeout from 1 to 5 seconds for retrieving results from the queue.