### PR TITLE
fix: image filename sanitization to match Markdown references

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,9 @@ def _worker_convert(file_path_str: str, safe_filename: str, config: dict, result
         metadata_file.write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
         for img_name, img_data in images.items():
-            safe_img_name = re.sub(r'[^\w\-]', '_', img_name)
+            # Strip extension if present before sanitizing
+            base_name, _ = os.path.splitext(img_name)
+            safe_img_name = re.sub(r'[^\w\-]', '_', base_name)
             safe_img_name = re.sub(r'_+', '_', safe_img_name)
             if not safe_img_name:
                 safe_img_name = "image"


### PR DESCRIPTION
This pull request makes a targeted improvement to the image filename sanitization logic in the `_worker_convert` function in `main.py`. The change ensures that image filenames are sanitized more robustly by first removing the file extension before replacing unsafe characters.

* Improved image filename sanitization: Now, the code strips the file extension from `img_name` before applying the regular expression to replace unsafe characters, resulting in cleaner and more predictable filenames for generated images. (`main.py`, [main.pyL155-R157](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L155-R157))…pping original extension before adding `.jpeg`